### PR TITLE
This adds the ability to use credentials v2 and adds more tests.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -1,81 +1,79 @@
 # @digitalbazaar/vc-bitstring-status-list
 
-[Verifiable Credential Bitstring Status List1](https://github.com/w3c/vc-bitstring-status-list/)
+[Verifiable Credential Bitstring Status List](https://github.com/w3c/vc-bitstring-status-list/)
 
 ### Creating a BitstringStatusListCredential
 
 ```js
-const sl = require("@digitalbazaar/vc-bitstring-status-list");
-const jsigs = require("jsonld-signatures");
-const {Ed25519KeyPair} = require("crypto-ld");
-const vc = require("vc-js");
-const documentLoader = require("./path-to/document-loader.js");
+import {
+  BitstringStatusList,
+  createCredential,
+  VC_BSL_VC_V1_CONTEXT,
+  VC_BSL_VC_V2_CONTEXT
+} from '@digitalbazaar/vc-bitstring-status-last';
+import {documentLoader} from './path-to/document-loader.js';
+import {Ed25519Signature2020} from '@digitalbazaar/ed25519-signature-2020';
+import {Ed25519VerificationKey2020} from
+  '@digitalbazaar/ed25519-verification-key-2020';
+import {issue} from '@digitalbazaar/vc';
 
-const key = new Ed25519KeyPair({
-  "id": "did:key:z6MknUVLM84Eo5mQswCqP7f6oNER84rmVKkCvypob8UtBC8K#z6MknUVLM84Eo5mQswCqP7f6oNER84rmVKkCvypob8UtBC8K",
-  "controller": "did:key:z6MknUVLM84Eo5mQswCqP7f6oNER84rmVKkCvypob8UtBC8K",
-  "type": "Ed25519VerificationKey2018",
-  "privateKeyBase58": "CoZphRAfAVPqx9f54MRUBtmjD4uY6KPxQQKsE3frUbZ269tBD4AdTQAVbXHHgpewh4BunoXK8dotcUJ6JXhZPsh",
-  "publicKeyBase58": "92EHksooTYGwmSN8hYhFxGgRJVav5SVrExuskrWsFyLw"
-});
-const suite = new Ed25519Signature2018({
-  key,
-  date: "2019-12-11T03:50:55Z",
-});
-const id = "https://example.com/credentials/status/3";
-const list = await sl.createList({length: 100000});
-const encodedList = await list.encode();
-const slCredential = {
-  "@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/ns/credentails/status/v1"],
+// Issuer Setup
+const key = new Ed25519VerificationKey2020({
+  id: 'did:key:z6Mkrjy3khhKz1jPLEwhqYAWNn3xMURog2DdCqjWAmD6anRE#z6Mkrjy3khhKz1jPLEwhqYAWNn3xMURog2DdCqjWAmD6anRE',
+  controller: 'did:key:z6Mkrjy3khhKz1jPLEwhqYAWNn3xMURog2DdCqjWAmD6anRE',
+  publicKeyMultibase: 'z6Mkrjy3khhKz1jPLEwhqYAWNn3xMURog2DdCqjWAmD6anRE',
+  privateKeyMultibase: 'zrv5NrLP4CvUQPGqpoFFCq6ihnEJWF7DpA1r13cxqzeJcSWjbgpXabWbCuHPUUSYhCknd3qWxEfT2ax7cR8TcYr4Dkt'
+})
+const suite = new Ed25519Signature2020({key});
+
+// Status List Details
+const id = 'https://example.com/credentials/status/3';
+const list = BitstringStatusList({length: 100000});
+const statusPurpose = 'revocation';
+
+// Create BitstringStatusListCredential
+const credential = await createCredential({
   id,
-  issuer: "did:key:z6MknUVLM84Eo5mQswCqP7f6oNER84rmVKkCvypob8UtBC8K",
-  issuanceDate: "2021-03-10T04:24:12.164Z",
-  type: ["VerifiableCredential", "BitstringStatusListCredential"],
-  credentialSubject: {
-    id: `${id}#list`,
-    type: "BitstringStatusList",
-    encodedList,
-  },
-};
-let verifiableCredential = await vc.issue({
-  credential: {...slCredential},
-  suite,
-  documentLoader,
+  list,
+  statusPurpose,
+  context: VC_BSL_VC_V2_CONTEXT // OR VC_BSL_VC_V1_CONTEXT for VCDM v1
 });
+
+// Create BitstringStatusListCredential Verifiable Credential
+const statusVC = await issue({credential, suite, documentLoader})
 ```
 
-### Created a Credential which uses a BitstringStatusList
+### Create a Verifiable Credential which uses a BitstringStatusList
 
 ```js
 // see imports above
 const credential = {
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1",
-    "https://www.w3.org/ns/credentials/status/v1",
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://www.w3.org/2018/credentials/examples/v1',
+    'https://www.w3.org/ns/credentials/status/v1'
   ],
-  id: "https://example.com/credentials/3732",
-  type: ["VerifiableCredential", "UniversityDegreeCredential"],
-  issuer: "did:web:did.actor:alice",
-  issuanceDate: "2021-03-10T04:24:12.164Z",
+  id: 'https://example.com/credentials/3732',
+  type: ['VerifiableCredential', 'UniversityDegreeCredential'],
+  issuer: suite.key.controller,
+  issuanceDate: '2021-03-10T04:24:12.164Z',
   credentialStatus: {
-    id: "https://example.com/credentials/status/3#94567",
-    type: "BitstringStatusListEntry",
-    statusListIndex: "94567",
-    statusListCredential:
-      "https://did.actor/alice/credentials/status/3",
+    id: 'https://example.com/credentials/status/3#94567',
+    type: 'BitstringStatusListEntry',
+    statusListIndex: '94567',
+    statusListCredential: 'https://example.com/credentials/status/3'
   },
   credentialSubject: {
-    id: "did:web:did.actor:bob",
+    id: 'did:web:did.actor:bob',
     degree: {
-      type: "BachelorDegree",
-      name: "Bachelor of Science and Arts",
-    },
-  },
+      type: 'BachelorDegree',
+      name: 'Bachelor of Science and Arts',
+    }
+  }
 };
-let verifiableCredential = await vc.issue({
+let verifiableCredential = await issue({
   credential: {...credential},
   suite,
-  documentLoader,
+  documentLoader
 });
 ```

--- a/lib/BitstringStatusList.js
+++ b/lib/BitstringStatusList.js
@@ -21,12 +21,14 @@ export class BitstringStatusList {
   }
 
   async encode() {
-    return this.bitstring.encodeBits();
+    return 'u' + await this.bitstring.encodeBits();
   }
 
   static async decode({encodedList}) {
     try {
-      const buffer = await Bitstring.decodeBits({encoded: encodedList});
+      const buffer = await Bitstring.decodeBits({
+        encoded: encodedList.slice(1)
+      });
       return new BitstringStatusList({buffer});
     } catch(e) {
       if(e instanceof Error) {

--- a/lib/BitstringStatusList.js
+++ b/lib/BitstringStatusList.js
@@ -26,6 +26,9 @@ export class BitstringStatusList {
 
   static async decode({encodedList}) {
     try {
+      if(encodedList[0] !== 'u') {
+        throw '"encodedList" must start with the character "u".';
+      }
       const buffer = await Bitstring.decodeBits({
         encoded: encodedList.slice(1)
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,11 +31,12 @@ export async function decodeList({encodedList}) {
  * @param {BitstringStatusList} options.list - An instance of
  *   BitstringStatusList.
  * @param {string} options.statusPurpose - The purpose of the status entry.
- * @param {string} options.vcdmVersion - The VC Data Model version (1 or 2).
+ * @param {Array.string} options.context - The context(s) to use for the
+ *   credential.
  *
  * @returns {object} The resulting `BitstringStatusList Credential`.
  */
-export async function createCredential({id, list, statusPurpose, vcdmVersion}) {
+export async function createCredential({id, list, statusPurpose, context}) {
   if(!(id && typeof id === 'string')) {
     throw new TypeError('"id" is required.');
   }
@@ -45,11 +46,12 @@ export async function createCredential({id, list, statusPurpose, vcdmVersion}) {
   if(!(statusPurpose && typeof statusPurpose === 'string')) {
     throw new TypeError('"statusPurpose" is required.');
   }
-  const contexts = !vcdmVersion || vcdmVersion === 1 ?
-    [VC_V1_CONTEXT_URL, VC_BSL_V1_CONTEXT_URL] : [VC_V2_CONTEXT_URL];
+  if(!context) {
+    context = [VC_V2_CONTEXT_URL];
+  }
   const encodedList = await list.encode();
   return {
-    '@context': contexts,
+    '@context': context,
     id,
     type: ['VerifiableCredential', 'BitstringStatusListCredential'],
     credentialSubject: {
@@ -93,9 +95,10 @@ export function statusTypeMatches({credential} = {}) {
   if(!Array.isArray(contexts)) {
     throw new TypeError('"@context" must be an array.');
   }
-  if(contexts[0] !== VC_V1_CONTEXT_URL) {
+  if(contexts[0] !== VC_V1_CONTEXT_URL && contexts[0] !== VC_V2_CONTEXT_URL) {
     throw new Error(
-      `The first "@context" value must be "${VC_V1_CONTEXT_URL}".`);
+      `The first "@context" value must be "${VC_V1_CONTEXT_URL}" or ` +
+      `"${VC_V2_CONTEXT_URL}".`);
   }
   const {credentialStatus} = credential;
   if(!credentialStatus) {
@@ -309,7 +312,7 @@ async function _checkStatuses({
  * Takes in a credentialStatus an ensures it meets the
  * normative statements from the Bitstring Status List spec.
  *
- * @see https://w3c.github.io/vc-bitstring-status-list/
+ * @see https://www.w3.org/TR/vc-bitstring-status-list/
  *
  * @param {object} options - Options to use.
  * @param {object} options.credentialStatus - A credentialStatus.

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,9 @@ import {verifyCredential as vcVerifyCredential} from '@digitalbazaar/vc';
 
 const VC_V1_CONTEXT_URL = credentialsCtx.constants.CREDENTIALS_CONTEXT_V1_URL;
 
+export const VC_BSL_VC_V1_CONTEXT = [VC_V1_CONTEXT_URL, VC_BSL_V1_CONTEXT_URL];
+export const VC_BSL_VC_V2_CONTEXT = [VC_V2_CONTEXT_URL];
+
 export {BitstringStatusList};
 
 export async function createList({length}) {
@@ -47,7 +50,13 @@ export async function createCredential({id, list, statusPurpose, context}) {
     throw new TypeError('"statusPurpose" is required.');
   }
   if(!context) {
-    context = [VC_V2_CONTEXT_URL];
+    context = [...VC_BSL_VC_V2_CONTEXT];
+  } else if(
+    !context.every((e, i) => e === VC_BSL_VC_V1_CONTEXT[i]) &&
+    !context.every((e, i) => e === VC_BSL_VC_V2_CONTEXT[i])
+  ) {
+    throw new TypeError(`"context" must be either "[${VC_BSL_VC_V1_CONTEXT}]"` +
+      ` or "[${VC_BSL_VC_V2_CONTEXT}]".`);
   }
   const encodedList = await list.encode();
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,9 @@ import credentialsCtx from 'credentials-context';
 import {
   CONTEXT_URL as VC_BSL_V1_CONTEXT_URL
 } from '@digitalbazaar/vc-bitstring-status-list-context';
-//import {
-//  CONTEXT_URL as VC_V2_CONTEXT_URL
-//} from '@digitalbazaar/credentials-v2-context';
+import {
+  CONTEXT_URL as VC_V2_CONTEXT_URL
+} from '@digitalbazaar/credentials-v2-context';
 import {verifyCredential as vcVerifyCredential} from '@digitalbazaar/vc';
 
 const VC_V1_CONTEXT_URL = credentialsCtx.constants.CREDENTIALS_CONTEXT_V1_URL;
@@ -31,10 +31,11 @@ export async function decodeList({encodedList}) {
  * @param {BitstringStatusList} options.list - An instance of
  *   BitstringStatusList.
  * @param {string} options.statusPurpose - The purpose of the status entry.
+ * @param {string} options.vcdmVersion - The VC Data Model version (1 or 2).
  *
  * @returns {object} The resulting `BitstringStatusList Credential`.
  */
-export async function createCredential({id, list, statusPurpose}) {
+export async function createCredential({id, list, statusPurpose, vcdmVersion}) {
   if(!(id && typeof id === 'string')) {
     throw new TypeError('"id" is required.');
   }
@@ -44,9 +45,11 @@ export async function createCredential({id, list, statusPurpose}) {
   if(!(statusPurpose && typeof statusPurpose === 'string')) {
     throw new TypeError('"statusPurpose" is required.');
   }
+  const contexts = !vcdmVersion || vcdmVersion === 1 ?
+    [VC_V1_CONTEXT_URL, VC_BSL_V1_CONTEXT_URL] : [VC_V2_CONTEXT_URL];
   const encodedList = await list.encode();
   return {
-    '@context': [VC_V1_CONTEXT_URL, VC_BSL_V1_CONTEXT_URL],
+    '@context': contexts,
     id,
     type: ['VerifiableCredential', 'BitstringStatusListCredential'],
     credentialSubject: {
@@ -117,6 +120,9 @@ export function assertBitstringStatusListContext({credential} = {}) {
   const {'@context': contexts} = credential;
   if(!Array.isArray(contexts)) {
     throw new TypeError('"@context" must be an array.');
+  }
+  if(contexts[0] === VC_V2_CONTEXT_URL) {
+    return;
   }
   if(contexts[0] !== VC_V1_CONTEXT_URL) {
     throw new Error(

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,11 +52,11 @@ export async function createCredential({id, list, statusPurpose, context}) {
   if(!context) {
     context = [...VC_BSL_VC_V2_CONTEXT];
   } else if(
-    !context.every((e, i) => e === VC_BSL_VC_V1_CONTEXT[i]) &&
-    !context.every((e, i) => e === VC_BSL_VC_V2_CONTEXT[i])
-  ) {
-    throw new TypeError(`"context" must be either "[${VC_BSL_VC_V1_CONTEXT}]"` +
-      ` or "[${VC_BSL_VC_V2_CONTEXT}]".`);
+    !(context.every((e, i) => e === VC_BSL_VC_V1_CONTEXT[i]) ||
+    context.every((e, i) => e === VC_BSL_VC_V2_CONTEXT[i]))) {
+    throw new TypeError(
+      `"context" must be either "${VC_BSL_VC_V1_CONTEXT}" ` +
+      `or "${VC_BSL_VC_V2_CONTEXT}".`);
   }
   const encodedList = await list.encode();
   return {
@@ -105,7 +105,7 @@ export function statusTypeMatches({credential} = {}) {
     throw new TypeError('"@context" must be an array.');
   }
   if(contexts[0] !== VC_V1_CONTEXT_URL && contexts[0] !== VC_V2_CONTEXT_URL) {
-    throw new Error(
+    throw new TypeError(
       `The first "@context" value must be "${VC_V1_CONTEXT_URL}" or ` +
       `"${VC_V2_CONTEXT_URL}".`);
   }
@@ -137,7 +137,7 @@ export function assertBitstringStatusListContext({credential} = {}) {
     return;
   }
   if(contexts[0] !== VC_V1_CONTEXT_URL) {
-    throw new Error(
+    throw new TypeError(
       `The first "@context" value must be "${VC_V1_CONTEXT_URL}".`);
   }
   if(!contexts.includes(VC_BSL_V1_CONTEXT_URL)) {
@@ -171,16 +171,18 @@ export function getCredentialStatus({credential, statusPurpose} = {}) {
   }
   const credentialStatuses = _getStatuses({credential});
   if(credentialStatuses.length === 0) {
-    throw new Error('"credentialStatus" with type "BitstringStatusListEntry" ' +
-    `and status purpose "${statusPurpose}" not found.`);
+    throw new Error(
+      '"credentialStatus" with type "BitstringStatusListEntry" ' +
+      `and status purpose "${statusPurpose}" not found.`);
   }
   const result = credentialStatuses.filter(
     credentialStatus => _validateStatus({credentialStatus})).find(
     // check for matching `statusPurpose`
     cs => cs.statusPurpose === statusPurpose);
   if(!result) {
-    throw new Error('"credentialStatus" with type "BitstringStatusListEntry" ' +
-    `and status purpose "${statusPurpose}" not found.`);
+    throw new Error(
+      '"credentialStatus" with type "BitstringStatusListEntry" ' +
+      `and status purpose "${statusPurpose}" not found.`);
   }
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@digitalbazaar/bitstring": "^3.0.0",
     "@digitalbazaar/credentials-v2-context": "github:digitalbazaar/credentials-v2-context#main",
-    "@digitalbazaar/vc": "^5.0.0",
+    "@digitalbazaar/vc": "github:digitalbazaar/vc#credentials-v2",
     "@digitalbazaar/vc-bitstring-status-list-context": "github:digitalbazaar/vc-bitstring-status-list-context#initial",
     "credentials-context": "^2.0.0"
   },

--- a/tests/10-BitstringStatusList.spec.js
+++ b/tests/10-BitstringStatusList.spec.js
@@ -64,9 +64,8 @@ describe('BitstringStatusList', () => {
       err = e;
     }
     should.exist(err);
-    err.message.should.contain(
-      'Could not decode encoded status list; reason: incorrect header check'
-    );
+    err.message.should.include(
+      '"encodedList" must start with the character "u".');
     should.not.exist(list);
   });
 
@@ -138,7 +137,7 @@ describe('BitstringStatusList', () => {
       err = e;
     }
     should.exist(err);
-    err.name.should.equal('TypeError');
-    err.message.should.equal('"buffer" must be a Uint8Array.');
+    err.message.should.include(
+      '"encodedList" must start with the character "u".');
   });
 });

--- a/tests/10-BitstringStatusList.spec.js
+++ b/tests/10-BitstringStatusList.spec.js
@@ -4,9 +4,9 @@
 import {BitstringStatusList} from '../lib/BitstringStatusList.js';
 
 const encodedList100k =
-  'H4sIAAAAAAAAA-3BMQEAAADCoPVPbQsvoAAAAAAAAAAAAAAAAP4GcwM92tQwAAA';
+  'uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQsvoAAAAAAAAAAAAAAAAP4GcwM92tQwAAA';
 const encodedList100KWith50KthRevoked =
-  'H4sIAAAAAAAAA-3OMQ0AAAgDsElHOh72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFvRitn7UMAAA';
+  'uH4sIAAAAAAAAA-3OMQ0AAAgDsElHOh72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFvRitn7UMAAA';
 
 describe('BitstringStatusList', () => {
   it('should create an instance', async () => {
@@ -26,7 +26,7 @@ describe('BitstringStatusList', () => {
       err.name.should.equal('TypeError');
     });
 
-  it('should encode', async () => {
+  it('should encode (multibase formatted)', async () => {
     const list = new BitstringStatusList({length: 100000});
     let encodedList;
     let err;

--- a/tests/10-BitstringStatusList.spec.js
+++ b/tests/10-BitstringStatusList.spec.js
@@ -53,6 +53,23 @@ describe('BitstringStatusList', () => {
     list.length.should.equal(100000);
   });
 
+  it('should fail to decode non-multibase encoded list', async () => {
+    let err;
+    let list;
+    try {
+      list = await BitstringStatusList.decode({
+        encodedList: encodedList100k.slice(1)
+      });
+    } catch(e) {
+      err = e;
+    }
+    should.exist(err);
+    err.message.should.contain(
+      'Could not decode encoded status list; reason: incorrect header check'
+    );
+    should.not.exist(list);
+  });
+
   it('should mark a credential revoked', async () => {
     const list = new BitstringStatusList({length: 8});
     list.getStatus(0).should.equal(false);

--- a/tests/10-BitstringStatusList.spec.js
+++ b/tests/10-BitstringStatusList.spec.js
@@ -129,4 +129,16 @@ describe('BitstringStatusList', () => {
     const decodedList = await BitstringStatusList.decode({encodedList});
     decodedList.getStatus(50000).should.equal(true);
   });
+
+  it('should fail when decoding an empty string', async () => {
+    let err;
+    try {
+      await BitstringStatusList.decode({encodedList: ''});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(err);
+    err.name.should.equal('TypeError');
+    err.message.should.equal('"buffer" must be a Uint8Array.');
+  });
 });

--- a/tests/20-main.spec.js
+++ b/tests/20-main.spec.js
@@ -9,7 +9,8 @@ import {
   createList,
   decodeList,
   getCredentialStatus,
-  statusTypeMatches
+  statusTypeMatches,
+  VC_BSL_VC_V1_CONTEXT
 } from '../lib/index.js';
 import {defaultDocumentLoader, issue} from '@digitalbazaar/vc';
 import {
@@ -204,10 +205,7 @@ describe('createCredential', () => {
 describe('statusTypeMatches', () => {
   it('should find a match', async () => {
     const credential = {
-      '@context': [
-        'https://www.w3.org/2018/credentials/v1',
-        VC_BSL_V1_CONTEXT_URL
-      ],
+      '@context': VC_BSL_VC_V1_CONTEXT,
       id: 'urn:uuid:a0418a78-7924-11ea-8a23-10bf48838a41',
       type: ['VerifiableCredential', 'example:TestCredential'],
       credentialSubject: {
@@ -228,10 +226,7 @@ describe('statusTypeMatches', () => {
 
   it('should not find a match', async () => {
     const credential = {
-      '@context': [
-        'https://www.w3.org/2018/credentials/v1',
-        VC_BSL_V1_CONTEXT_URL
-      ],
+      '@context': VC_BSL_VC_V1_CONTEXT,
       id: 'urn:uuid:a0418a78-7924-11ea-8a23-10bf48838a41',
       type: ['VerifiableCredential', 'example:TestCredential'],
       credentialSubject: {

--- a/tests/20-main.spec.js
+++ b/tests/20-main.spec.js
@@ -1305,7 +1305,7 @@ describe('assertBitstringStatusListContext', () => {
     const id = 'https://example.com/status/1';
     const list = await createList({length: 100000});
     const credential = await createCredential(
-      {id, list, statusPurpose: 'revocation', vcdmVersion: 2});
+      {id, list, statusPurpose: 'revocation'});
 
     let err;
     let result;

--- a/tests/mock-sl-credentials.js
+++ b/tests/mock-sl-credentials.js
@@ -1,67 +1,46 @@
 /*!
  * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
+import {Ed25519Signature2020} from '@digitalbazaar/ed25519-signature-2020';
+import {Ed25519VerificationKey2020} from
+  '@digitalbazaar/ed25519-verification-key-2020';
+import {issue} from '@digitalbazaar/vc';
 import suiteCtx2020 from 'ed25519-signature-2020-context';
-import {
-  CONTEXT_URL as VC_BSL_V1_CONTEXT_URL
-} from '@digitalbazaar/vc-bitstring-status-list-context';
 
 const SUITE_CONTEXT_URL = suiteCtx2020.constants.CONTEXT_URL;
 
 const encodedList100KWith50KthRevoked =
-  'H4sIAAAAAAAAA-3OMQ0AAAgDsOHfNB72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFrc4zDz' +
+  'uH4sIAAAAAAAAA-3OMQ0AAAgDsOHfNB72EJJWQRMAAAAAAIDWXAcAAAAAAIDHFrc4zDz' +
   'UMAAA';
 
-export const slCredentialRevocation = {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    VC_BSL_V1_CONTEXT_URL,
-    SUITE_CONTEXT_URL
-  ],
-  id: 'https://example.com/status/1',
-  issuer: 'did:key:z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5UjBop',
-  issuanceDate: '2022-06-02T16:00:21Z',
-  type: ['VerifiableCredential', 'BitstringStatusListCredential'],
-  credentialSubject: {
-    id: 'https://example.com/status/1#list',
-    type: 'BitstringStatusList',
-    encodedList: encodedList100KWith50KthRevoked,
-    statusPurpose: 'revocation'
-  },
-  proof: {
-    type: 'Ed25519Signature2020',
-    created: '2024-02-09T06:43:18Z',
-    verificationMethod: 'did:key:z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5U' +
-      'jBop#z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5UjBop',
-    proofPurpose: 'assertionMethod',
-    proofValue: 'z5R731MjeqiZdMrbUCTu9eKMZ1MQbdzVBH6h3poSK6v2m5qGWQsTym3FFHuy' +
-      '13PGqnJpRiARZ9jkXSi7CMxkySo3E'
+export async function createMockBitstringStatusListCredential({
+  id, suite, statusPurpose, documentLoader
+}) {
+  if(!id) {
+    id = 'https://example.com/status/1';
   }
-};
-
-export const slCredentialSuspension = {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    VC_BSL_V1_CONTEXT_URL,
-    SUITE_CONTEXT_URL
-  ],
-  id: 'https://example.com/status/2',
-  issuer: 'did:key:z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5UjBop',
-  issuanceDate: '2022-06-02T16:06:22Z',
-  type: ['VerifiableCredential', 'BitstringStatusListCredential'],
-  credentialSubject: {
-    id: 'https://example.com/status/2#list',
-    type: 'BitstringStatusList',
-    encodedList: encodedList100KWith50KthRevoked,
-    statusPurpose: 'suspension'
-  },
-  proof: {
-    type: 'Ed25519Signature2020',
-    created: '2024-02-09T06:43:18Z',
-    verificationMethod: 'did:key:z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5' +
-      'UjBop#z6MkowtnRyMkCerXvXqjCYUo2mLEeCgX1sWfoP2CZA5UjBop',
-    proofPurpose: 'assertionMethod',
-    proofValue: 'z5DvJ59aVSb3QkhWvhVWXcjfhk4CLhDfvcusMDaLky7dmSJNEbf3WLxXPzP' +
-      'wcMFVZ2StM1xrPc99ashXFeWhhh7Co'
+  if(!suite) {
+    const keyPair = await Ed25519VerificationKey2020.generate();
+    const {publicKeyMultibase} = keyPair;
+    keyPair.id = `did:key:${publicKeyMultibase}#${publicKeyMultibase}`;
+    keyPair.controller = `did:key:${publicKeyMultibase}`;
+    suite = new Ed25519Signature2020({key: keyPair});
   }
-};
+  const credential = {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      SUITE_CONTEXT_URL
+    ],
+    id,
+    issuer: suite.key.controller,
+    issuanceDate: '2022-06-02T16:00:21Z',
+    type: ['VerifiableCredential', 'BitstringStatusListCredential'],
+    credentialSubject: {
+      id: `${id}#list`,
+      type: 'BitstringStatusList',
+      encodedList: encodedList100KWith50KthRevoked,
+      statusPurpose
+    }
+  };
+  return issue({credential, suite, documentLoader});
+}


### PR DESCRIPTION
from the Initial files PR
- [ ]  Check tests match the vc-bitstring-status-list spec vs the vc-status-list[-2021] one.
- [ ]  Add more tests to cover new features and properties (ttl, statusReference, stsatusSize, statusMessage, etc).
- [x]  Mock encodedList data needs to be multibase formatted.
- [x]  Add tests to catch non-multibase encodedList.
- [x]  Mock data likely needs to be re-generated to get valid new signatures. (I'm not sure where this data came from or if a script exists to do this.)
- [x]  The tests are based on VC V1 context. In theory the context should be compatible with V2, which should likely be tested, even though the context is redundant.