### PR TITLE
Use vc-2.0-time-props branch for latest VC 2.0 code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@digitalbazaar/bitstring": "^3.0.0",
     "@digitalbazaar/credentials-v2-context": "github:digitalbazaar/credentials-v2-context#main",
-    "@digitalbazaar/vc": "github:digitalbazaar/vc#credentials-v2",
+    "@digitalbazaar/vc": "github:digitalbazaar/vc#vc-2.0-time-props",
     "@digitalbazaar/vc-bitstring-status-list-context": "^1.0.0",
     "credentials-context": "^2.0.0"
   },


### PR DESCRIPTION
This library depends on a stale branch of `@digitalbazaar/vc` in particular this branch: https://github.com/digitalbazaar/vc/blob/credentials-v2/package.json

That branch in turn depends on a non-existent branch of: https://github.com/digitalbazaar/credentials-v2-context/branches

So this PR ensures that vc-bitstring-status-list is at least using a branch of vc that depends on existent branches of other libraries. 

